### PR TITLE
Changing function name to conform to Nuxt documentation

### DIFF
--- a/server/api/healthz.get.ts
+++ b/server/api/healthz.get.ts
@@ -1,5 +1,5 @@
 import { users } from '~/server/db/schema'
 
-export default defineLazyEventHandler(() => eventHandler(async (event) => {
+export default defineEventHandler(() => eventHandler(async (event) => {
   return await event.context.database.select().from(users).all()
 }))

--- a/server/api/healthz.get.ts
+++ b/server/api/healthz.get.ts
@@ -1,5 +1,5 @@
 import { users } from '~/server/db/schema'
 
-export default defineEventHandler(() => eventHandler(async (event) => {
+export default defineEventHandler(async (event) => {
   return await event.context.database.select().from(users).all()
-}))
+});


### PR DESCRIPTION
See https://nuxt.com/docs/guide/directory-structure/server: 

```
Each file should export a default function defined with defineEventHandler() or eventHandler() (alias).
```